### PR TITLE
Fix Compilation Errors

### DIFF
--- a/ArduinoSNMP.h
+++ b/ArduinoSNMP.h
@@ -966,7 +966,10 @@ typedef struct SNMP_PDU {
     t_v->OID.clear();
     t_v->clear();
     t_v->OID.fromString("1.3.6.1.2.1.1.3.0");//OID of the value type being sent
-    t_v->encode(SNMP_SYNTAX_TIME_TICKS, millis()/10);
+    //This line below causes error, millis() type doesn't have a definite type. 
+    //This produces different candidates for one overloaded function call.
+    //t_v->encode(SNMP_SYNTAX_TIME_TICKS, millis()/10);
+    t_v->encode(SNMP_SYNTAX_TIME_TICKS, (const uint16_t)millis()/10);
     value.size = add_data_private(t_v);
     
     //SNMPv2 trapOID


### PR DESCRIPTION
Error text:
Compiling debug version of 'ServerGuardianSNMP_Stage1' for 'LOLIN(WEMOS) D1 R2 & mini'
 
ArduinoSNMP.cpp:21: In file included from
ArduinoSNMP.h: In member function void SNMP_PDU::prepare_trapv2(SNMP_VALUE*)
 
ArduinoSNMP.h: 970:51: error: call of overloaded 'encode(SNMP_SYNTAXES, long unsigned int)' is ambiguous
   t_v->encode(SNMP_SYNTAX_TIME_TICKS, millis() \ 10)

Compiling on esp8266 Core version 2.4.2 using Visual Studio and vMicro based on Arduino IDE version 1.4/1.6.
The errors were because of the millis() function, as it seems like compiler can't detect the type of the millis(), although it detects the reference. So the compiler detects multiple candidates and causes the preceding error. There is also a similar one in ArduinoSNMP.cpp.