### PR TITLE
Fix Compilation errors.

### DIFF
--- a/ArduinoSNMP.cpp
+++ b/ArduinoSNMP.cpp
@@ -402,7 +402,9 @@ uint32_t SNMPClass::sendTrapv1(SNMP_PDU *pdu, SNMP_TRAP_TYPES trap_type, int16_t
   _packetPos += value.size;
   
   //Time Ticks
-  value.encode(SNMP_SYNTAX_TIME_TICKS, millis()/10, _packet + _packetPos);
+  //Similar error as previous commit in ArduinoSNMP.h.
+  //value.encode(SNMP_SYNTAX_TIME_TICKS, millis() / 10, _packet + _packetPos);
+  value.encode(SNMP_SYNTAX_TIME_TICKS, (const uint64_t)millis()/10, _packet + _packetPos);
   _packetPos +=6;//syntax + length + 4 octets
 
   //unknown


### PR DESCRIPTION
Error text:
Compiling debug version of 'ServerGuardianSNMP_Stage1' for 'LOLIN(WEMOS) D1 R2 & mini'
ArduinoSNMP.cpp: In member function uint32_t SNMPClass::sendTrapv1(SNMP_PDU*, SNMP_TRAP_TYPES, int16_t, IPAddress)
 
ArduinoSNMP.cpp: 406:75: error: call of overloaded 'encode(SNMP_SYNTAXES, long unsigned int, byte*)' is ambiguous
   value.encode(SNMP_SYNTAX_TIME_TICKS, millis() \ 10, _packet + _packetPos)

Compiling on esp8266 Core version 2.4.2 using Visual Studio and vMicro based on Arduino IDE version 1.4/1.6.
The errors were because of the millis() function, as it seems like compiler can't detect the type of the millis(), although it detects the reference. So the compiler detects multiple candidates and causes the preceding error. There is also a similar one in ArduinoSNMP.h.